### PR TITLE
Clear nullability warnings in omnisharp/server.ts

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -97,14 +97,14 @@ async function pickProjectAndStart(server: OmniSharpServer, optionProvider: Opti
 }
 
 export async function showProjectSelector(server: OmniSharpServer, targets: LaunchTarget[]): Promise<void> {
-    return vscode.window.showQuickPick(targets, {
+    const launchTarget = await vscode.window.showQuickPick(targets, {
         matchOnDescription: true,
         placeHolder: `Select 1 of ${targets.length} projects`
-    }).then(async launchTarget => {
-        if (launchTarget) {
-            return server.restart(launchTarget);
-        }
     });
+
+    if (launchTarget !== undefined) {
+        return server.restart(launchTarget);
+    }
 }
 
 interface Command {

--- a/src/observers/OmnisharpDebugModeLoggerObserver.ts
+++ b/src/observers/OmnisharpDebugModeLoggerObserver.ts
@@ -57,7 +57,7 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleOmnisharpServerRequestCancelled(event: OmnisharpServerRequestCancelled) {
-        this.logger.appendLine(`Cancelled request for ${event.command} (${event.id}).`);
+        this.logger.appendLine(`Cancelled request for ${event.command}${event.id ? ` (${event.id})` : ''}.`);
         this.logger.appendLine();
     }
 

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -125,7 +125,7 @@ export class OmnisharpServerDequeueRequest implements BaseEvent {
 
 export class OmnisharpServerRequestCancelled implements BaseEvent {
     type = EventType.OmnisharpServerRequestCancelled;
-    constructor(public command: string, public id: number) { }
+    constructor(public command: string, public id: number | undefined) { }
 }
 
 export class OmnisharpServerProcessRequestStart implements BaseEvent {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -12,7 +12,7 @@ import * as serverUtils from '../omnisharp/utils';
 import { vscode, CancellationToken } from '../vscodeAdapter';
 import { ChildProcess, exec } from 'child_process';
 import { LaunchTarget, findLaunchTargets, LaunchTargetKind } from './launcher';
-import { ReadLine, createInterface } from 'readline';
+import { createInterface } from 'readline';
 import { Request, RequestQueueCollection } from './requestQueue';
 import { DelayTracker } from './delayTracker';
 import { EventEmitter } from 'events';
@@ -83,7 +83,6 @@ const latestVersionFileServerPath = 'releases/versioninfo.txt';
 export class OmniSharpServer {
 
     private static _nextId = 1;
-    private _readLine: ReadLine;
     private _disposables: CompositeDisposable;
 
     private _delayTrackers!: { [requestName: string]: DelayTracker }; // Initialized via _start
@@ -660,7 +659,7 @@ export class OmniSharpServer {
             }
         });
 
-        this._readLine = createInterface({
+        const readLine = createInterface({
             input: this._serverProcess.stdout,
             output: this._serverProcess.stdin,
             terminal: false
@@ -694,10 +693,10 @@ export class OmniSharpServer {
 
         const lineReceived = this._onLineReceived.bind(this);
 
-        this._readLine.addListener('line', lineReceived);
+        readLine.addListener('line', lineReceived);
 
         this._disposables.add(new Disposable(() => {
-            this._readLine.removeListener('line', lineReceived);
+            readLine.removeListener('line', lineReceived);
         }));
 
         return promise;

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -542,7 +542,7 @@ export class OmniSharpServer {
     }
 
     public async restart(launchTarget: LaunchTarget | undefined = this._launchTarget): Promise<void> {
-        if (this._state.status == ServerState.Starting) {
+        if (this._state.status === ServerState.Starting) {
             this.eventStream.post(new ObservableEvents.OmnisharpServerOnServerError("Attempt to restart OmniSharp server failed because another server instance is starting."));
             return;
         }
@@ -615,13 +615,12 @@ export class OmniSharpServer {
         // Otherwise, we fire the "MultipleLaunchTargets" event,
         // which is handled in status.ts to display the launch target selector.
         this._fireEvent(Events.MultipleLaunchTargets, launchTargets);
-        return await showProjectSelector(this, launchTargets);
+        return showProjectSelector(this, launchTargets);
     }
 
     // --- requests et al
 
     public async makeRequest<TResponse>(command: string, data?: any, token?: CancellationToken): Promise<TResponse> {
-
         if (!this.isRunning()) {
             return Promise.reject<TResponse>('OmniSharp server is not running.');
         }
@@ -629,7 +628,7 @@ export class OmniSharpServer {
         let startTime: number;
         let request: Request;
 
-        let promise = new Promise<TResponse>((resolve, reject) => {
+        const promise = new Promise<TResponse>((resolve, reject) => {
             startTime = Date.now();
 
             request = {
@@ -642,7 +641,7 @@ export class OmniSharpServer {
             this._requestQueue.enqueue(request);
         });
 
-        if (token) {
+        if (token !== undefined) {
             token.onCancellationRequested(() => {
                 this.eventStream.post(new ObservableEvents.OmnisharpServerRequestCancelled(request.command, request.id));
                 this._requestQueue.cancelRequest(request);
@@ -664,7 +663,6 @@ export class OmniSharpServer {
         disposables: CompositeDisposable,
         serverProcess: ChildProcess,
         options: Options): Promise<void> {
-
         serverProcess.stderr.on('data', (data: Buffer) => {
             let trimData = removeBOMFromBuffer(data);
             if (trimData.length > 0) {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -96,7 +96,7 @@ export class OmniSharpServer {
 
     private static _nextId = 1;
 
-    private _delayTrackers!: { [requestName: string]: DelayTracker }; // Initialized via _start
+    private _delayTrackers: { [requestName: string]: DelayTracker } = {};
 
     private _eventBus = new EventEmitter();
     private _state: State = { status: ServerState.Stopped };


### PR DESCRIPTION
Mostly, this adds a mini state machine to server.ts that controls which variables can be accessed.

I believe there's the following behavior changes to watch out for:
* `_makeRequest` now errors out if a request is sent when the server isn't running. (This would throw an uncaught exception anyway because of `this._serverProcess` being undefined, now it's just explicit.)
* `stop` now short-circuits if the server is already stopped. (Theoretically, it should also error if it's called when the server is starting. Currently that's guarded by `restart` -- but the check should really be in `stop` itself.)
* `autoStart` now calls `_start` directly rather than going through `restart`. Given how it's called autoStart, I feel like this makes sense.

My naming scheme for ServerState and State is terrible. Please advise on better names for them :).